### PR TITLE
Update text, and color link on Admin notice

### DIFF
--- a/studio-demo-site-companion.php
+++ b/studio-demo-site-companion.php
@@ -21,7 +21,7 @@ function studio_companion_admin_notices() {
 		<p class="studio_welcome">
 			<?php echo sprintf(
 			/* translators: %s: URL to Studio landing page. */
-				__( 'This preview site will be <b>deleted in 7 days from the last update</b>. <a href="%s">Try Studio by WordPress.com ↗</a>' ),
+				__( 'This demo site will be <b>deleted in 7 days from the last update</b>. <a target="_blank" href="%s">Try Studio by WordPress.com ↗</a>' ),
 				'https://developer.wordpress.com/studio/'
 			); ?>
 		</p>
@@ -34,6 +34,15 @@ function studio_companion_admin_notices() {
         .studio_welcome {
             align-items: center;
         }
+
+		.studio_welcome a {
+			color: #3858E9;
+			text-decoration: none;
+		}
+
+		.studio_welcome a:hover {
+			text-decoration: underline;
+		}
 	</style>
 	<?php
 }


### PR DESCRIPTION
- Related: https://github.com/Automattic/dotcom-forge/issues/5513

# Description

Update admin notice.
Changed preview links to demo links , open the studio link in a new tab and update the color link.

# Testing instructions
* Add this plugin into a website. For example in Studio, wp-now or production.
* Navigate to /wp-admin
* Observe the changes mentioned in the description


https://github.com/Automattic/studio-demo-site-companion/assets/779993/91c722fc-b7e4-467a-a930-908a6b4f76fd

