### PR TITLE
Fix paragraph tag margin specificity on #studio-companion-notice banner

### DIFF
--- a/studio-demo-site-companion.php
+++ b/studio-demo-site-companion.php
@@ -59,6 +59,10 @@ function studio_companion_enqueue_scripts() {
             text-decoration: underline;
         }
 
+        #studio-companion-notice p {
+            margin: 0;
+        }
+
         #studio-companion-notice a:hover {
             text-decoration: none;
         }

--- a/studio-demo-site-companion.php
+++ b/studio-demo-site-companion.php
@@ -59,12 +59,12 @@ function studio_companion_enqueue_scripts() {
             text-decoration: underline;
         }
 
-        #studio-companion-notice p {
-            margin: 0;
-        }
-
         #studio-companion-notice a:hover {
             text-decoration: none;
+        }
+
+        #studio-companion-notice p {
+            margin: 0;
         }
 
         #studio-companion-notice__close {


### PR DESCRIPTION
Resolves Automattic/dotcom-forge#7225

**Proposed Changes**
On certain themes (like Astra), the theme CSS specificity rules can override the paragraph margin display, which affects the banner layout.

This PR updates the child `<p>` margin rules to center the tag within the banner.

**Testing Instructions**
1. Manually apply the commit changes to the plugin
2. Test a demo site using the Astra theme

Before | After
-|-
<img width="584" alt="Screenshot 2024-05-17 at 3 15 52 pm" src="https://github.com/Automattic/studio-demo-site-companion/assets/643285/bbc8c9c0-99b6-4d95-92ec-0cb98f4035ea"> | <img width="599" alt="Screenshot 2024-05-17 at 3 15 59 pm" src="https://github.com/Automattic/studio-demo-site-companion/assets/643285/2399e16d-c6a2-411b-aebc-84327b6fff80">
