### PR TITLE
Set margin explicitly to not rely on agent or theme

### DIFF
--- a/studio-demo-site-companion.php
+++ b/studio-demo-site-companion.php
@@ -64,7 +64,7 @@ function studio_companion_enqueue_scripts() {
         }
 
         #studio-companion-notice p {
-            margin: 0;
+            margin: 14px 0;
         }
 
         #studio-companion-notice__close {


### PR DESCRIPTION
Related issue: https://github.com/Automattic/dotcom-forge/issues/7461

## Description

I propose explicitly setting the margin for the banner paragraph to ensure it works in the 2024 and Astra themes.

Before | After
-|-
![Screenshot 2024-05-28 at 14 41 21](https://github.com/Automattic/studio-demo-site-companion/assets/727413/5c3ed151-67ee-4264-b6b8-6f20789ed2b1) | <img width="1358" alt="Screenshot 2024-05-29 at 14 54 16" src="https://github.com/Automattic/studio-demo-site-companion/assets/727413/9dd56ce8-e07d-49b1-b9da-f697345435fc">

And Astra:

<img width="1356" alt="Screenshot 2024-05-29 at 14 54 28" src="https://github.com/Automattic/studio-demo-site-companion/assets/727413/33305ea9-4243-41ba-8c3b-e61b8d18e6db">

## Testing instructions

1. Create a site in Studio
2. Add this plugin file `studio-demo-site-companion.php` directly into the `wp-content/mu-plugins/` folder and ensure it's enabled
3. Load frontend and confirm that the demo notice has a margin as on the design
5. Switch to Astra theme
3. Load frontend and confirm that the demo notice has a margin as on the design