### PR TITLE
Studio: Rename demo sites to preview sites

### DIFF
--- a/studio-demo-site-companion.php
+++ b/studio-demo-site-companion.php
@@ -17,7 +17,7 @@ function studio_companion_admin_notices() {
 	?>
 	<div class="notice notice-warning is-dismissible studio_notice">
 		<p class="studio_welcome">
-			<?php echo __( 'This demo site will be <b>deleted in 7 days from the last update</b>.' ); ?>
+			<?php echo __( 'This preview site will be <b>deleted in 7 days from the last update</b>.' ); ?>
 		</p>
 	</div>
     <style>
@@ -87,7 +87,7 @@ function studio_companion_enqueue_scripts() {
             var studioCompanionNotice = <?php echo json_encode(array(
             'description' => sprintf(
                 /* translators: %s: URL to WordPress.com hosting landing page. */
-                __( 'You\'re previewing a <b>Studio</b> demo site, powered by <a href="%s" target="_blank">WordPress.com hosting  ↗</a>' ),
+                __( 'This is a <b>Studio</b> preview site, powered by <a href="%s" target="_blank">WordPress.com hosting  ↗</a>' ),
                 'https://wordpress.com/hosting/?utm_source=studio_demo_site&utm_medium=referral&utm_campaign=demo_sites_frontend'
             ),
         )); ?>;


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/10448

This PR renames the `demo sites` to `preview sites` for the frontend and backend notices that are displayed on demo sites.

**Testing instructions**

* Create a site in Studio
* Add this plugin file `studio-demo-site-companion.php` directly into the `wp-content/mu-plugins/` folder and ensure it's enabled
* Load frontend and confirm the wording says `preview site`

<img width="1236" alt="Screenshot 2025-02-13 at 11 22 00 AM" src="https://github.com/user-attachments/assets/21b2b6c9-4560-4216-8889-01d0ab4394b1" />

* Switch to backend
* Confirm that the notice in WP Admin mentions `preview site` and not `demo site`

<img width="1072" alt="Screenshot 2025-02-13 at 11 06 41 AM" src="https://github.com/user-attachments/assets/95598041-463e-4422-acfd-dbae8b45ecb7" />
