### PR TITLE
Ensure the notice isn't rendered with a fallback emoji.

### DIFF
--- a/studio-demo-site-companion.php
+++ b/studio-demo-site-companion.php
@@ -101,6 +101,7 @@ function studio_companion_enqueue_scripts() {
             var closeButton = document.createElement("button");
 
             notice.setAttribute("id", "studio-companion-notice");
+			notice.setAttribute("class", "wp-exclude-emoji");
             notice.innerHTML = logoSvg;
 
             paragraph.innerHTML = studioCompanionNotice.description;


### PR DESCRIPTION
Before:
<img width="574" height="54" alt="Screenshot 2026-04-24 at 5 08 06 pm" src="https://github.com/user-attachments/assets/80f15726-9c33-4206-8a1f-2ce94763ee38" />

After:
<img width="566" height="55" alt="Screenshot 2026-04-24 at 5 09 18 pm" src="https://github.com/user-attachments/assets/0176d6a8-d41c-454e-85d5-e27891f6b6e2" />
